### PR TITLE
Add cotizacion deletion route and service

### DIFF
--- a/ventas/application/CotizacionService.js
+++ b/ventas/application/CotizacionService.js
@@ -492,6 +492,44 @@ class CotizacionService {
 
     return cotizacion;
   }
+
+  async deleteCotizacion(id_cotizacion, usuario = null) {
+    try {
+      const detalles = await DetalleCotizacionRepository.findByCotizacionId(
+        id_cotizacion
+      );
+
+      for (const detalle of detalles) {
+        await DetalleCotizacionRepository.delete(detalle.id_detalle);
+      }
+
+      const deleted = await CotizacionRepository.delete(id_cotizacion);
+
+      if (deleted) {
+        if (usuario) {
+          try {
+            await LogCotizacionRepository.create({
+              id_cotizacion,
+              accion: "anulación",
+              fecha: new Date(),
+              usuario,
+              detalle: `Cotización ${id_cotizacion} eliminada`,
+            });
+          } catch (logError) {
+            console.error(
+              "Error registrando log de eliminación de cotización:",
+              logError
+            );
+          }
+        }
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      throw new Error(`Error al eliminar la cotización: ${error.message}`);
+    }
+  }
 }
 
 export default new CotizacionService();

--- a/ventas/infrastructure/controllers/CotizacionController.js
+++ b/ventas/infrastructure/controllers/CotizacionController.js
@@ -87,7 +87,8 @@ class CotizacionController {
   async deleteCotizacion(req, res) {
     try {
       const { id } = req.params; // ID de la cotización enviada en la URL
-      const deleted = await CotizacionService.deleteCotizacion(id);
+      const rut = req.user?.id;
+      const deleted = await CotizacionService.deleteCotizacion(id, rut);
 
       if (!deleted) {
         return res

--- a/ventas/infrastructure/routes/CotizacionRoutes.js
+++ b/ventas/infrastructure/routes/CotizacionRoutes.js
@@ -11,6 +11,11 @@ router.get("/:id/pdf", checkPermissions("ventas.cotizacion.pdf"), CotizacionCont
 router.get("/:id", checkPermissions("ventas.cotizacion.ver"), CotizacionController.getCotizacionById);
 router.put("/:id", checkPermissions("ventas.cotizacion.editar"), CotizacionController.actualizarCotizacion);
 router.post("/", checkPermissions("ventas.cotizacion.crear"), CotizacionController.createCotizacion);
+router.delete(
+  "/:id",
+  checkPermissions("ventas.cotizacion.eliminar"),
+  CotizacionController.deleteCotizacion
+);
 
 
 


### PR DESCRIPTION
## Summary
- implement `deleteCotizacion` in `CotizacionService`
- pass user to service from controller
- expose DELETE endpoint in `CotizacionRoutes`

## Testing
- `npm test` *(fails: no test specified)*