### PR TITLE
Implement pedido deletion logic

### DIFF
--- a/ventas/application/PedidoService.js
+++ b/ventas/application/PedidoService.js
@@ -18,6 +18,7 @@ import CajaRepository from "../infrastructure/repositories/CajaRepository.js";
 import WebSocketServer from "../../shared/websockets/WebSocketServer.js";
 import DocumentoRepository from "../infrastructure/repositories/DocumentoRepository.js";
 import { obtenerFechaActualChile } from "../../shared/utils/fechaUtils.js";
+import { estadosInvalidosPedido } from "../../shared/utils/estadoUtils.js";
 
 class PedidoService {
   // Se crea en Pendiente
@@ -817,6 +818,17 @@ class PedidoService {
   }
 
   async deletePedido(id_pedido) {
+    const pedido = await PedidoRepository.findById(id_pedido);
+    if (!pedido) {
+      return null;
+    }
+
+    if (!estadosInvalidosPedido.includes(pedido.id_estado_pedido)) {
+      throw new Error(
+        "No se puede eliminar un pedido que no está en estado permitido."
+      );
+    }
+
     await DetallePedidoRepository.deleteByPedidoId(id_pedido);
     return await PedidoRepository.delete(id_pedido);
   }

--- a/ventas/infrastructure/repositories/DetallePedidoRepository.js
+++ b/ventas/infrastructure/repositories/DetallePedidoRepository.js
@@ -28,6 +28,10 @@ class DetallePedidoRepository {
     return await DetallePedido.destroy({ where: { id_detalle_pedido: id } });
   }
 
+  async deleteByPedidoId(id_pedido) {
+    return await DetallePedido.destroy({ where: { id_pedido } });
+  }
+
   getModel() {
     return DetallePedido;
   }

--- a/ventas/infrastructure/routes/PedidosRoutes.js
+++ b/ventas/infrastructure/routes/PedidosRoutes.js
@@ -20,6 +20,11 @@ router.put("/desasignar/:id_pedido", checkPermissions("ventas.pedido.desasignar"
 router.post("/", checkPermissions("ventas.pedido.crear"), PedidoController.createPedido);
 router.post("/registrar-desde-pedido", checkPermissions("ventas.pedido.pago"), PedidoController.registrarDesdePedido);
 router.patch("/:id_pedido/confirmacion", checkPermissions("ventas.pedido.confirmar"), checkRoles(['chofer']), PedidoController.confirmarPedido);
+router.delete(
+  "/:id_pedido",
+  checkPermissions("ventas.pedido.eliminar"),
+  PedidoController.eliminarPedido
+);
 
 
 export default router;


### PR DESCRIPTION
## Summary
- allow mass deletion of DetallePedido via `deleteByPedidoId`
- validate pedido state before deleting
- expose deletion endpoint on pedidos routes

## Testing
- `npm test` *(fails: Error: no test specified)*