### PR TITLE
Implement soft delete flow for pedidos

### DIFF
--- a/ventas/application/PedidoService.js
+++ b/ventas/application/PedidoService.js
@@ -625,6 +625,22 @@ class PedidoService {
     return await PedidoRepository.findById(id_pedido);
   }
 
+  async rejectPedido(id_pedido) {
+    const estadoRechazado = await EstadoVentaRepository.findByNombre(
+      "Rechazado"
+    );
+
+    if (!estadoRechazado) {
+      throw new Error("Estado 'Rechazado' no configurado.");
+    }
+
+    await PedidoRepository.update(id_pedido, {
+      id_estado_pedido: estadoRechazado.id_estado_venta,
+    });
+
+    return await PedidoRepository.findById(id_pedido);
+  }
+
   async getPedidoById(id_pedido) {
     return await PedidoRepository.findById(id_pedido);
   }

--- a/ventas/infrastructure/controllers/PedidoController.js
+++ b/ventas/infrastructure/controllers/PedidoController.js
@@ -263,6 +263,25 @@ class PedidoController {
     }
   }
 
+  async rechazarPedido(req, res) {
+    try {
+      const { id_pedido } = req.params;
+      const pedido = await PedidoService.rejectPedido(id_pedido);
+
+      if (!pedido)
+        return res.status(404).json({ message: "Pedido no encontrado" });
+
+      res.status(200).json({
+        message: "Pedido rechazado correctamente",
+        pedido,
+      });
+    } catch (error) {
+      res
+        .status(500)
+        .json({ message: `Error al rechazar pedido: ${error.message}` });
+    }
+  }
+
   async desasignarPedido(req, res) {
     try {
       const { id_pedido } = req.params;

--- a/ventas/infrastructure/routes/PedidosRoutes.js
+++ b/ventas/infrastructure/routes/PedidosRoutes.js
@@ -20,6 +20,11 @@ router.put("/desasignar/:id_pedido", checkPermissions("ventas.pedido.desasignar"
 router.post("/", checkPermissions("ventas.pedido.crear"), PedidoController.createPedido);
 router.post("/registrar-desde-pedido", checkPermissions("ventas.pedido.pago"), PedidoController.registrarDesdePedido);
 router.patch("/:id_pedido/confirmacion", checkPermissions("ventas.pedido.confirmar"), checkRoles(['chofer']), PedidoController.confirmarPedido);
+router.put(
+  "/:id_pedido/rechazar",
+  checkPermissions("ventas.pedido.editar"),
+  PedidoController.rechazarPedido
+);
 router.delete(
   "/:id_pedido",
   checkPermissions("ventas.pedido.eliminar"),


### PR DESCRIPTION
## Summary
- support rejecting pedidos before deletion
- expose new `rechazar` route in `PedidosRoutes`
- handle request via `PedidoController.rechazarPedido`

## Testing
- `npm test` *(fails: no test specified)*
