### PR TITLE
Add endpoint to revert rejected orders

### DIFF
--- a/ventas/application/PedidoService.js
+++ b/ventas/application/PedidoService.js
@@ -672,6 +672,37 @@ class PedidoService {
     return await PedidoRepository.findById(id_pedido);
   }
 
+  async revertPedido(id_pedido) {
+    const pedido = await PedidoRepository.findById(id_pedido);
+
+    if (!pedido) {
+      throw new Error("Pedido no encontrado.");
+    }
+
+    const estadoActual = await EstadoVentaRepository.findById(
+      pedido.id_estado_pedido
+    );
+
+    if (!estadoActual) {
+      throw new Error("Estado de pedido inválido.");
+    }
+
+    if (estadoActual.nombre_estado !== "Rechazado") {
+      throw new Error("Solo puedes revertir pedidos en estado 'Rechazado'.");
+    }
+
+    const estadoPendiente = await EstadoVentaRepository.findByNombre("Pendiente");
+    if (!estadoPendiente) {
+      throw new Error("Estado 'Pendiente' no configurado.");
+    }
+
+    await PedidoRepository.update(id_pedido, {
+      id_estado_pedido: estadoPendiente.id_estado_venta,
+    });
+
+    return await PedidoRepository.findById(id_pedido);
+  }
+
   async getPedidoById(id_pedido) {
     return await PedidoRepository.findById(id_pedido);
   }

--- a/ventas/infrastructure/controllers/PedidoController.js
+++ b/ventas/infrastructure/controllers/PedidoController.js
@@ -282,6 +282,25 @@ class PedidoController {
     }
   }
 
+  async revertirPedido(req, res) {
+    try {
+      const { id_pedido } = req.params;
+      const pedido = await PedidoService.revertPedido(id_pedido);
+
+      if (!pedido)
+        return res.status(404).json({ message: "Pedido no encontrado" });
+
+      res.status(200).json({
+        message: "Pedido revertido correctamente",
+        pedido,
+      });
+    } catch (error) {
+      res
+        .status(500)
+        .json({ message: `Error al revertir pedido: ${error.message}` });
+    }
+  }
+
   async desasignarPedido(req, res) {
     try {
       const { id_pedido } = req.params;

--- a/ventas/infrastructure/routes/PedidosRoutes.js
+++ b/ventas/infrastructure/routes/PedidosRoutes.js
@@ -25,6 +25,11 @@ router.put(
   checkPermissions("ventas.pedido.editar"),
   PedidoController.rechazarPedido
 );
+router.put(
+  "/:id_pedido/revertir",
+  checkPermissions("ventas.pedido.editar"),
+  PedidoController.revertirPedido
+);
 router.delete(
   "/:id_pedido",
   checkPermissions("ventas.pedido.eliminar"),


### PR DESCRIPTION
## Summary
- add `revertPedido` service for switching a rejected order back to `Pendiente`
- expose new controller action `revertirPedido`
- add route `PUT /:id_pedido/revertir`

## Testing
- `npm test` *(fails: Error: no test specified)*