### PR TITLE
Add pendientes route for producto retornables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Sistema de Gestión de Recursos - Backend
+
+## Endpoints
+
+### GET /api/producto-retornable/pendientes
+Obtiene la lista de productos retornables en estado `pendiente_inspeccion`.
+
+Sin parámetros.
+
+**Solicitud**
+```
+GET /api/producto-retornable/pendientes
+```
+
+**Respuesta exitosa**
+```json
+[
+  {
+    "id_producto_retornable": 1,
+    "estado": "pendiente_inspeccion",
+    "id_producto": 5,
+    "id_cliente": 2
+  }
+]
+```

--- a/inventario/infrastructure/controllers/ProductoRetonableController.js
+++ b/inventario/infrastructure/controllers/ProductoRetonableController.js
@@ -21,6 +21,15 @@ class ProductoRetornableController {
     }
   }
 
+  async getPendientes(req, res) {
+    try {
+      const pendientes = await ProductoRetornableService.getAllProductosRetornables({ estado: "pendiente_inspeccion" });
+      res.status(200).json(pendientes);
+    } catch (error) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
   async createProductoRetornable(req, res) {
     try {
       const data = req.body;

--- a/inventario/infrastructure/routes/ProductoRetornableRoutes.js
+++ b/inventario/infrastructure/routes/ProductoRetornableRoutes.js
@@ -7,6 +7,11 @@ const router = Router();
 router.use(authenticate)
 
 router.get("/:id", checkPermissions("inventario.productoretornable.ver"), ProductoRetornableController.getProductoRetornableById);
+router.get(
+  "/pendientes",
+  checkPermissions("inventario.productoretornable.ver"),
+  ProductoRetornableController.getPendientes
+);
 router.post("/", checkPermissions("inventario.productoretornable.ver"), ProductoRetornableController.getAllProductosRetornables);
 router.post("/create", checkPermissions("inventario.productoretornable.crear"), ProductoRetornableController.createProductoRetornable);
 router.put("/:id", checkPermissions("inventario.productoretornable.editar"), ProductoRetornableController.updateProductoRetornable);


### PR DESCRIPTION
## Summary
- add `getPendientes` handler in `ProductoRetonableController`
- expose `GET /pendientes` route for producto retornables
- document request and response format for the new endpoint

## Testing
- `npm test`
