### PR TITLE
Add truck id tracking for returnables

### DIFF
--- a/Entregas/application/InventarioCamionService.js
+++ b/Entregas/application/InventarioCamionService.js
@@ -134,6 +134,7 @@ class InventarioCamionService {
               cantidad: item.cantidad,
               estado: "pendiente_inspeccion",
               fecha_retorno: new Date(),
+              id_camion,
             },
             { transaction }
           );

--- a/inventario/domain/models/ProductoRetornable.js
+++ b/inventario/domain/models/ProductoRetornable.js
@@ -3,6 +3,7 @@ import Producto from "./Producto.js";
 import sequelize from "../../../database/database.js";
 import Entrega from "../../../Entregas/domain/models/Entrega.js";
 import Venta from "../../../ventas/domain/models/Venta.js";
+import Camion from "../../../Entregas/domain/models/Camion.js";
 
 const ProductoRetornable = sequelize.define(
   "ProductoRetornable",
@@ -30,10 +31,18 @@ const ProductoRetornable = sequelize.define(
     },
     id_venta: {
       type: DataTypes.INTEGER,
-      allowNull: true, 
+      allowNull: true,
       references: {
         model: Venta,
         key: "id_venta",
+      },
+    },
+    id_camion: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: Camion,
+        key: "id_camion",
       },
     },
     cantidad: {

--- a/inventario/infrastructure/repositories/ProductoRetornableRepository.js
+++ b/inventario/infrastructure/repositories/ProductoRetornableRepository.js
@@ -41,14 +41,7 @@ class ProductoRetornableRepository {
 
   async updateByCamionAndProducto(id_camion, id_producto, data, options = {}) {
     return await ProductoRetornable.update(data, {
-      where: { id_producto },
-      include: [
-        {
-          model: Entrega,
-          as: "entrega",
-          where: { id_camion },
-        },
-      ],
+      where: { id_camion, id_producto },
       ...options,
     });
   }

--- a/migrations/20250615000000-add-id_camion-to-productoretornable.js
+++ b/migrations/20250615000000-add-id_camion-to-productoretornable.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("ProductoRetornable", "id_camion", {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: { model: "Camion", key: "id_camion" },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("ProductoRetornable", "id_camion");
+  },
+};

--- a/test/productoRetornableService.test.js
+++ b/test/productoRetornableService.test.js
@@ -35,6 +35,8 @@ test('inspeccionarRetornables procesa items correctamente', async () => {
   await ProductoRetornableService.inspeccionarRetornables(5, items);
 
   assert.equal(updateCalls.length, 2);
+  assert.equal(updateCalls[0].id_camion, 5);
+  assert.equal(updateCalls[1].id_camion, 5);
   assert.equal(incrementCalls.length, 1);
   assert.equal(deleteCalls.length, 2);
 });


### PR DESCRIPTION
## Summary
- add `id_camion` field to ProductoRetornable model
- create migration to add this field
- store truck id when unloading in `vaciarCamion`
- update `updateByCamionAndProducto` to filter directly on truck id
- adjust product returnables tests to verify truck id passed

## Testing
- `npm test`