### PR TITLE
Fix transaction forwarding in camion inventory queries

### DIFF
--- a/Entregas/application/InventarioCamionService.js
+++ b/Entregas/application/InventarioCamionService.js
@@ -54,7 +54,7 @@ class InventarioCamionService {
   ) {
     const inventarioCamion = await InventarioCamionRepository.findAllByCamionId(
       id_camion,
-      transaction
+      { transaction }
     );
 
     for (const item of inventarioCamion) {

--- a/Entregas/infrastructure/repositories/InventarioCamionRepository.js
+++ b/Entregas/infrastructure/repositories/InventarioCamionRepository.js
@@ -135,7 +135,7 @@ class InventarioCamionRepository {
     });
   }
 
-  async findAllByCamionId(id_camion) {
+  async findAllByCamionId(id_camion, options = {}) {
     return await InventarioCamion.findAll({
       where: { id_camion },
       include: [
@@ -150,6 +150,7 @@ class InventarioCamionRepository {
           ],
         },
       ],
+      ...options,
     });
   }
 

--- a/test/inventarioCamionRepository.test.js
+++ b/test/inventarioCamionRepository.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import InventarioCamionRepository from '../Entregas/infrastructure/repositories/InventarioCamionRepository.js';
+import InventarioCamion from '../Entregas/domain/models/InventarioCamion.js';
+import InventarioCamionService from '../Entregas/application/InventarioCamionService.js';
+
+const originalFindAll = InventarioCamion.findAll;
+const originalRepoMethod = InventarioCamionRepository.findAllByCamionId;
+
+test('findAllByCamionId forwards transaction to model', async () => {
+  let received = null;
+  InventarioCamion.findAll = async (opts) => {
+    received = opts;
+    return [];
+  };
+  const tx = {};
+  await InventarioCamionRepository.findAllByCamionId(1, { transaction: tx });
+  assert.equal(received.transaction, tx);
+});
+
+test('descargarItemsCamion forwards transaction to repository', async () => {
+  let repoOpts = null;
+  InventarioCamionRepository.findAllByCamionId = async (id, opts) => {
+    repoOpts = opts;
+    return [];
+  };
+  const tx = {};
+  await InventarioCamionService.descargarItemsCamion(
+    1,
+    { descargarRetorno: true, descargarDisponibles: true },
+    tx
+  );
+  assert.equal(repoOpts.transaction, tx);
+});
+
+test('cleanup', () => {
+  InventarioCamion.findAll = originalFindAll;
+  InventarioCamionRepository.findAllByCamionId = originalRepoMethod;
+});


### PR DESCRIPTION
## Summary
- allow `InventarioCamionRepository.findAllByCamionId` to accept options
- ensure `descargarItemsCamion` forwards `{ transaction }`
- test that repository and service honour transaction parameter

## Testing
- `npm test`