### PR TITLE
Add Camion association to retornables

### DIFF
--- a/inventario/domain/associate-models.js
+++ b/inventario/domain/associate-models.js
@@ -7,6 +7,7 @@ import Insumo from "./models/Insumo.js";
 import TipoInsumo from "./models/TipoInsumo.js";
 import ProductoRetornable from "./models/ProductoRetornable.js";
 import Venta from "../../ventas/domain/models/Venta.js";
+import Camion from "../../Entregas/domain/models/Camion.js";
 import FormulaProducto from "./models/FormulaProducto.js";
 import FormulaProductoDetalle from "./models/FormulaProductoDetalle.js";
 
@@ -98,6 +99,9 @@ function loadInventarioAssociations() {
 
   Venta.hasMany(ProductoRetornable, { foreignKey: "id_venta" });
   ProductoRetornable.belongsTo(Venta, { foreignKey: "id_venta" });
+
+  ProductoRetornable.belongsTo(Camion, { foreignKey: "id_camion", as: "camion" });
+  Camion.hasMany(ProductoRetornable, { foreignKey: "id_camion", as: "productosRetornables" });
 
   /*   ProductoRetornable.belongsTo(EstadoProductoRetornable, {
     foreignKey: "id_estado",

--- a/inventario/infrastructure/repositories/ProductoRetornableRepository.js
+++ b/inventario/infrastructure/repositories/ProductoRetornableRepository.js
@@ -2,6 +2,7 @@ import ProductoRetornable from "../../domain/models/ProductoRetornable.js";
 import Producto from "../../domain/models/Producto.js";
 import Insumo from "../../domain/models/Insumo.js";
 import Entrega from "../../../Entregas/domain/models/Entrega.js";
+import Camion from "../../../Entregas/domain/models/Camion.js";
 
 class ProductoRetornableRepository {
   async findById(id) {
@@ -10,6 +11,7 @@ class ProductoRetornableRepository {
         { model: Producto, as: "Producto" },
         { model: Insumo, as: "insumo" },
         { model: Entrega, as: "entrega" },
+        { model: Camion, as: "camion" },
       ],
     });
   }
@@ -21,6 +23,7 @@ class ProductoRetornableRepository {
         { model: Producto, as: "Producto" },
         { model: Insumo, as: "insumo" },
         { model: Entrega, as: "entrega" },
+        { model: Camion, as: "camion" },
       ],
       ...options,
     });

--- a/test/productoRetornableRepository.test.js
+++ b/test/productoRetornableRepository.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import ProductoRetornableRepository from '../inventario/infrastructure/repositories/ProductoRetornableRepository.js';
+import ProductoRetornable from '../inventario/domain/models/ProductoRetornable.js';
+
+const originalFindByPk = ProductoRetornable.findByPk;
+const originalFindAll = ProductoRetornable.findAll;
+
+test('findById includes camion association', async () => {
+  let opts = null;
+  ProductoRetornable.findByPk = async (id, options) => {
+    opts = options;
+    return null;
+  };
+  await ProductoRetornableRepository.findById(1);
+  const hasCamion = opts.include.some(i => i.as === 'camion');
+  assert.equal(hasCamion, true);
+});
+
+test('findAll includes camion association', async () => {
+  let opts = null;
+  ProductoRetornable.findAll = async (options) => {
+    opts = options;
+    return [];
+  };
+  await ProductoRetornableRepository.findAll();
+  const hasCamion = opts.include.some(i => i.as === 'camion');
+  assert.equal(hasCamion, true);
+});
+
+test('cleanup', () => {
+  ProductoRetornable.findByPk = originalFindByPk;
+  ProductoRetornable.findAll = originalFindAll;
+});


### PR DESCRIPTION
## Summary
- link `ProductoRetornable` with `Camion` in model associations
- include the camion relation in `ProductoRetornableRepository`
- test repository methods for camion include