### PR TITLE
Fix retorno creation to include id_camion

### DIFF
--- a/Entregas/application/InventarioCamionService.js
+++ b/Entregas/application/InventarioCamionService.js
@@ -66,6 +66,7 @@ class InventarioCamionService {
             cantidad: item.cantidad,
             estado: "pendiente_inspeccion",
             fecha_retorno: new Date(),
+            id_camion,
           },
           { transaction }
         );
@@ -497,6 +498,7 @@ class InventarioCamionService {
           estado: "defectuoso",
           tipo_defecto,
           fecha_retorno: new Date(),
+          id_camion,
         });
       }
 


### PR DESCRIPTION
## Summary
- pass `id_camion` to `ProductoRetornableRepository.create` when downloading items from a truck
- include `id_camion` when registering returned items