### PR TITLE
Support retornable updates by insumo

### DIFF
--- a/inventario/application/ProductoRetornableService.js
+++ b/inventario/application/ProductoRetornableService.js
@@ -49,6 +49,7 @@ class ProductoRetornableService {
       await ProductoRetornableRepository.updateByCamionAndProducto(
         id_camion,
         item.id_producto,
+        item.id_insumo,
         {
           estado: item.estado,
           tipo_defecto: item.estado === "defectuoso" ? item.tipo_defecto : null,

--- a/inventario/infrastructure/repositories/ProductoRetornableRepository.js
+++ b/inventario/infrastructure/repositories/ProductoRetornableRepository.js
@@ -44,9 +44,22 @@ class ProductoRetornableRepository {
     });
   }
 
-  async updateByCamionAndProducto(id_camion, id_producto, data, options = {}) {
+  async updateByCamionAndProducto(
+    id_camion,
+    id_producto,
+    id_insumo,
+    data,
+    options = {}
+  ) {
+    const where = { id_camion };
+    if (id_producto !== null && id_producto !== undefined) {
+      where.id_producto = id_producto;
+    } else {
+      where.id_insumo = id_insumo;
+    }
+
     return await ProductoRetornable.update(data, {
-      where: { id_camion, id_producto },
+      where,
       ...options,
     });
   }

--- a/test/productoRetornableService.test.js
+++ b/test/productoRetornableService.test.js
@@ -16,8 +16,14 @@ test('inspeccionarRetornables procesa items correctamente', async () => {
   const incrementCalls = [];
   const deleteCalls = [];
 
-  ProductoRetornableRepository.updateByCamionAndProducto = async (id_camion, id_producto, data, options) => {
-    updateCalls.push({ id_camion, id_producto, data });
+  ProductoRetornableRepository.updateByCamionAndProducto = async (
+    id_camion,
+    id_producto,
+    id_insumo,
+    data,
+    options
+  ) => {
+    updateCalls.push({ id_camion, id_producto, id_insumo, data });
     return [1];
   };
   InventarioService.incrementStock = async (id_producto, cantidad) => {
@@ -50,6 +56,27 @@ test('inspeccionarRetornables propaga errores', async () => {
     () => ProductoRetornableService.inspeccionarRetornables(5, [{ id_producto: 1, cantidad: 1, estado: 'reutilizable' }]),
     { message: 'fail' }
   );
+});
+
+test('inspeccionarRetornables pasa id_insumo cuando id_producto es null', async () => {
+  const updateCalls = [];
+  ProductoRetornableRepository.updateByCamionAndProducto = async (
+    id_camion,
+    id_producto,
+    id_insumo
+  ) => {
+    updateCalls.push({ id_camion, id_producto, id_insumo });
+    return [1];
+  };
+
+  const items = [
+    { id_producto: null, id_insumo: 5, cantidad: 1, estado: 'defectuoso' }
+  ];
+
+  await ProductoRetornableService.inspeccionarRetornables(3, items);
+
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0].id_insumo, 5);
 });
 
 test('getAllProductosRetornables filtra por estado pendiente_inspeccion', async () => {


### PR DESCRIPTION
## Summary
- allow updating retornables by `id_insumo` when `id_producto` is null
- send `id_insumo` from the service to the repository
- add unit test for updating by insumo

## Testing
- `npm test`